### PR TITLE
Replace bitrateMean with bitrateWeightedMean

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ You can use it from JSDelivr `https://cdn.jsdelivr.net/clappr.stats/latest/clapp
     duration: 0, // duration time in ms
     currentTime: 0, // current time in ms
     bitratesHistory: [], // the bitrates changes history
-    bitrateMean: 0, // bitrate mean (kbps)
-    bitrateVariance: 0, // bitrate variance (kbps)
-    bitrateStandardDeviation: 0, // bitrate standard deviation (kbps)
+    bitrateWeightedMean: 0, // bitrate weighted mean (kbps)
     bitrateMostUsed: 0, // most used (based on time) bitrate  (kbps)
     watchHistory: [], // an array of an array of watched range time ex: [0, 2200]
     watchedPercentage: 0, // % of watched time

--- a/index.js
+++ b/index.js
@@ -186,8 +186,10 @@ export default class ClapprStats extends ContainerPlugin {
   }
 
   _calculateBitrates() {
+    var bitratesWatchedTime = 0
     this._metrics.extra.bitrateWeightedMean = this._metrics.extra.bitratesHistory.map((x) => {
-      var bitrateTime = x.time || (this._now() - x.start)
+      bitratesWatchedTime += x.time || 0
+      var bitrateTime = x.time || (this._metrics.timers.watch - bitratesWatchedTime)
       return x.bitrate * bitrateTime
     }).reduce((a,b) => a + b, 0) / this._metrics.timers.watch
 


### PR DESCRIPTION
Related to issue #14.  
Replace the metric `bitrateMean` with `bitrateWeightedMean`.

In this approach, each bitrate contribute to the final metric with different weights (which corresponds to the time that user watched that bitrate).  
Reference: https://en.wikipedia.org/wiki/Weighted_arithmetic_mean

Besides that, the metrics `bitrateVariance` and `bitrateStandardDeviation` was removed.

**PS:** Note that in line 190, the time of the current bitrate is equal `now() - start`.  
This means that if the video is paused, the calculus will grow the same way it would grow if the video was playing.  
Makes sense?