### PR TITLE
Change percentage event

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 You can use it from JSDelivr `https://cdn.jsdelivr.net/clappr.stats/latest/clappr-stats.min.js` or as a npm package.
 
+Clappr-stats use Math.trunc method to fire percentage event, this method is not supported by Internet Explorer, please use a [polyfill](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc) to make compatible with IE.
+
 ```html
 <script>
     var player = new Clappr.Player({

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ You can use it from JSDelivr `https://cdn.jsdelivr.net/clappr.stats/latest/clapp
 
 Clappr-stats use Math.trunc method to fire percentage event, this method is not supported by Internet Explorer, please use a [polyfill](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc) to make compatible with IE.
 
+Clappr-stats will register two events CLAPPR_STATS_REPORT and CLAPPR_STATS_PERCENTAGE, those events can be listen this way:
+
+```javascript
+this.listenTo(this.container, Events.CLAPPR_STATS_REPORT, callback)
+this.listenTo(this.container, Events.CLAPPR_STATS_PERCENTAGE, callback)
+```
+
 ```html
 <script>
     var player = new Clappr.Player({
@@ -19,9 +26,6 @@ Clappr-stats use Math.trunc method to fire percentage event, this method is not 
         // optional: time in miliseconds for each report.
         // default: 5000
         runEach: 5000,
-        // optional: callback function.
-        // default: console.log
-        onReport: (metrics) => {console.log(metrics)},
         // Fire PERCENTAGE_EVENT when video complete some percentage.
         // default: []
         onCompletion: [10, 20, 55, 100],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "leandro.ribeiro.moreira@gmail.com",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "clappr": "^0.2.66",
+    "clappr": "^0.2.68",
     "lodash.get": "^4.3.0"
   },
   "devDependencies": {

--- a/src/clappr-stats.js
+++ b/src/clappr-stats.js
@@ -178,7 +178,7 @@ export default class ClapprStats extends ContainerPlugin {
   }
 
   _onCompletion() {
-    let currentPercentage = this._metrics.extra.watchedPercentage
+    let currentPercentage = Math.trunc(this._metrics.extra.watchedPercentage)
     let allPercentages = this._completion.watch
     let isCalled = this._completion.calls.indexOf(currentPercentage) != -1
 

--- a/src/clappr-stats.js
+++ b/src/clappr-stats.js
@@ -185,7 +185,7 @@ export default class ClapprStats extends ContainerPlugin {
     if (allPercentages.indexOf(currentPercentage) != -1 && !isCalled) {
       Log.info(this.name + ' PERCENTAGE_EVENT: ' + currentPercentage)
       this._completion.calls.push(currentPercentage)
-      this.trigger(ClapprStats.PERCENTAGE_EVENT, currentPercentage)
+      this.container.trigger(ClapprStats.PERCENTAGE_EVENT, currentPercentage)
     }
   }
 
@@ -202,7 +202,9 @@ export default class ClapprStats extends ContainerPlugin {
     this._measureLatency()
     this._measureBandwidth()
 
-    this.trigger(ClapprStats.REPORT_EVENT, JSON.parse(JSON.stringify(this._metrics)))
+    let data = JSON.parse(JSON.stringify(this._metrics))
+    this.container.trigger(ClapprStats.REPORT_EVENT, data)
+    this.trigger(ClapprStats.REPORT_EVENT, data)
   }
 
   _fetchFPS() {

--- a/src/clappr-stats.js
+++ b/src/clappr-stats.js
@@ -32,7 +32,7 @@ export default class ClapprStats extends ContainerPlugin {
     }
 
     this._newMetrics()
-    this.on(ClapprStats.REPORT_EVENT, this._onReport)
+    this.listenTo(this.container, Events.CLAPPR_STATS_REPORT, this._onReport)
   }
 
   bindEvents() {
@@ -185,7 +185,7 @@ export default class ClapprStats extends ContainerPlugin {
     if (allPercentages.indexOf(currentPercentage) != -1 && !isCalled) {
       Log.info(this.name + ' PERCENTAGE_EVENT: ' + currentPercentage)
       this._completion.calls.push(currentPercentage)
-      this.container.trigger(ClapprStats.PERCENTAGE_EVENT, currentPercentage)
+      this.container.trigger(Events.CLAPPR_STATS_PERCENTAGE, currentPercentage)
     }
   }
 
@@ -202,9 +202,7 @@ export default class ClapprStats extends ContainerPlugin {
     this._measureLatency()
     this._measureBandwidth()
 
-    let data = JSON.parse(JSON.stringify(this._metrics))
-    this.container.trigger(ClapprStats.REPORT_EVENT, data)
-    this.trigger(ClapprStats.REPORT_EVENT, data)
+    this.container.trigger(Events.CLAPPR_STATS_REPORT, JSON.parse(JSON.stringify(this._metrics)))
   }
 
   _fetchFPS() {
@@ -317,5 +315,5 @@ export default class ClapprStats extends ContainerPlugin {
   }
 }
 
-ClapprStats.REPORT_EVENT = 'clappr:stats:report'
-ClapprStats.PERCENTAGE_EVENT = 'clappr:stats:percentage'
+Events.register('CLAPPR_STATS_REPORT')
+Events.register('CLAPPR_STATS_PERCENTAGE')

--- a/test/clappr-stats.spec.js
+++ b/test/clappr-stats.spec.js
@@ -45,7 +45,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call REPORT_EVENT every time interval', () => {
-        this.plugin.on(ClapprStats.REPORT_EVENT, this.callback)
+        this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
         let attempts = randomNumber()
 
         this.simulator.play()
@@ -63,7 +63,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call PERCENTAGE_EVENT when PLAYBACK_TIMEUPDATE event is fired', () => {
-        this.plugin.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
+        this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
 
         this.simulator.play(10)
 
@@ -73,7 +73,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call PERCENTAGE_EVENT if video start in middle time and make seek for past', () => {
-        this.plugin.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
+        this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
 
         this.simulator.play(10)
         assert.isOk(this.callback.calledOnce)
@@ -83,7 +83,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call PERCENTAGE_EVENT once with the same state', () => {
-        this.plugin.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
+        this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
         
         this.simulator.play(4)
         assert.isOk(this.callback.calledOnce)
@@ -116,7 +116,7 @@ describe('Clappr Stats', () => {
     })
 
     it('should update counters', () => {
-        this.plugin.on(ClapprStats.REPORT_EVENT, this.callback)
+        this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
         
         this.simulator.play()
         this.simulator.enableFullscreen()
@@ -138,7 +138,7 @@ describe('Clappr Stats', () => {
     })
 
     it('should update timer', () => {
-        this.plugin.on(ClapprStats.REPORT_EVENT, this.callback)
+        this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
         
         this.simulator.play()
         this.clock.tick(this.timeInterval)

--- a/test/clappr-stats.spec.js
+++ b/test/clappr-stats.spec.js
@@ -2,6 +2,7 @@ import { expect, assert } from 'chai'
 
 import ClapprStats from '../src/clappr-stats'
 import { PlayerSimulator } from './util'
+import { Events } from 'clappr'
 
 import sinon from 'sinon'
 
@@ -41,7 +42,6 @@ describe('Clappr Stats', () => {
         }
 
         this.simulator = new PlayerSimulator(this.options, ClapprStats)
-        this.plugin = this.simulator.plugin
     })
 
     it('call callbackOption when REPORT_EVENT is fired', () => {
@@ -52,7 +52,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call REPORT_EVENT every time interval', () => {
-        this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
+        this.simulator.container.on(Events.CLAPPR_STATS_REPORT, this.callback)
         let attempts = randomNumber()
 
         this.simulator.play()
@@ -70,7 +70,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call PERCENTAGE_EVENT when PLAYBACK_TIMEUPDATE event is fired', () => {
-        this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
+        this.simulator.container.on(Events.CLAPPR_STATS_PERCENTAGE, this.callback)
 
         this.simulator.play(calculateFloatTime(25.22))
 
@@ -80,7 +80,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call PERCENTAGE_EVENT if video start in middle time and make seek for past', () => {
-        this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
+        this.simulator.container.on(Events.CLAPPR_STATS_PERCENTAGE, this.callback)
 
         this.simulator.play(calculateFloatTime(25.55))
         assert.isOk(this.callback.calledOnce)
@@ -93,7 +93,7 @@ describe('Clappr Stats', () => {
     })
 
     it('call PERCENTAGE_EVENT once with the same state', () => {
-        this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
+        this.simulator.container.on(Events.CLAPPR_STATS_PERCENTAGE, this.callback)
 
         this.simulator.play(calculateFloatTime(10.1))
         assert.isOk(this.callback.calledOnce)
@@ -126,7 +126,7 @@ describe('Clappr Stats', () => {
     })
 
     it('should update counters', () => {
-        this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
+        this.simulator.container.on(Events.CLAPPR_STATS_REPORT, this.callback)
 
         this.simulator.play()
         this.simulator.enableFullscreen()
@@ -148,7 +148,7 @@ describe('Clappr Stats', () => {
     })
 
     it('should update timer', () => {
-        this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
+        this.simulator.container.on(Events.CLAPPR_STATS_REPORT, this.callback)
 
         this.simulator.play()
         this.clock.tick(this.timeInterval)

--- a/test/clappr-stats.spec.js
+++ b/test/clappr-stats.spec.js
@@ -10,6 +10,13 @@ const randomNumber = (max=20, min=5) => {
     return Math.trunc(number)
 }
 
+const calculateFloatTime = (percentage, total=40) => {
+    // Clappr-Stats will calculate the watched percentage in milliseconds.
+    total = total * 1000
+    let time = (percentage / 100) * total
+    return time / 1000
+}
+
 describe('Clappr Stats', () => {
 
     before(() => {
@@ -65,7 +72,7 @@ describe('Clappr Stats', () => {
     it('call PERCENTAGE_EVENT when PLAYBACK_TIMEUPDATE event is fired', () => {
         this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
 
-        this.simulator.play(10)
+        this.simulator.play(calculateFloatTime(25.22))
 
         let percentage = this.callback.getCall(0).args[0]
 
@@ -75,20 +82,23 @@ describe('Clappr Stats', () => {
     it('call PERCENTAGE_EVENT if video start in middle time and make seek for past', () => {
         this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
 
-        this.simulator.play(10)
+        this.simulator.play(calculateFloatTime(25.55))
         assert.isOk(this.callback.calledOnce)
 
-        this.simulator.play(4)
+        this.simulator.play(calculateFloatTime(10.01))
         assert.isOk(this.callback.calledTwice)
+
+        this.simulator.play(calculateFloatTime(100.99))
+        assert.isOk(this.callback.calledThrice)
     })
 
     it('call PERCENTAGE_EVENT once with the same state', () => {
         this.plugin.container.on(ClapprStats.PERCENTAGE_EVENT, this.callback)
-        
-        this.simulator.play(4)
+
+        this.simulator.play(calculateFloatTime(10.1))
         assert.isOk(this.callback.calledOnce)
 
-        this.simulator.play(4)
+        this.simulator.play(calculateFloatTime(10.99))
         assert.isOk(this.callback.calledOnce)
     })
 
@@ -117,7 +127,7 @@ describe('Clappr Stats', () => {
 
     it('should update counters', () => {
         this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
-        
+
         this.simulator.play()
         this.simulator.enableFullscreen()
         this.simulator.pause()
@@ -139,7 +149,7 @@ describe('Clappr Stats', () => {
 
     it('should update timer', () => {
         this.plugin.container.on(ClapprStats.REPORT_EVENT, this.callback)
-        
+
         this.simulator.play()
         this.clock.tick(this.timeInterval)
 


### PR DESCRIPTION
**HAS BREAKING CHANGE**

The default in clappr-stats is fire PERCENTAGE_EVENT in plugin, now i modify to fire this event in container, for integration with another plugins.