### PR TITLE
Provide extra.bandwidth in bps (instead of kbps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can use it from JSDelivr `https://cdn.jsdelivr.net/clappr.stats/latest/clapp
     watchHistory: [], // an array of an array of watched range time ex: [0, 2200]
     watchedPercentage: 0, // % of watched time
     bufferingPercentage: 0, // % of buffering time
-    bandwidth: 0, // bandwidth in kbps
+    bandwidth: 0, // user bandwidth (bps)
   }
 }
 ```

--- a/src/clappr-stats.js
+++ b/src/clappr-stats.js
@@ -298,8 +298,7 @@ export default class ClapprStats extends ContainerPlugin {
       var done = (e) => {
         var timeSpent = (this._urisToMeasureBandwidth[i-1].end - this._urisToMeasureBandwidth[i-1].start) / 1000
         var bandwidthBps = (e.loaded * 8) / timeSpent
-        var bandwidthKbps = bandwidthBps / 1000
-        this._metrics.extra.bandwidth = bandwidthKbps
+        this._metrics.extra.bandwidth = bandwidthBps
         this._urisToMeasureBandwidth.forEach((x) => {
           x.start = 0
           x.end = 0


### PR DESCRIPTION
Replace the unit of metric `bandwidth` to maintain consistency with other data rate metrics (`bitrateWeightedMean` and `bitrateMostUsed `).