### PR TITLE
Fix race condition when timeupdate is fired between the pause event

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,8 @@
           parentId: '#player',
           plugins: [ClapprStats, DashShakaPlayback, LevelSelector],
           //source: '//storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd', //
-          source: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4',
+          // source: 'http://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4',
+          source: 'http://clappr.io/highline.mp4',
           //source: 'http://www.streambox.fr/playlists/x36xhzz/x36xhzz.m3u8',
           clapprStats: { onCompletion: [5, 20, 50, 70, 100] },
           height: 360,

--- a/src/clappr-stats.js
+++ b/src/clappr-stats.js
@@ -91,6 +91,7 @@ export default class ClapprStats extends ContainerPlugin {
   }
 
   playAfterPause() {
+    this.listenTo(this.container, Events.CONTAINER_TIMEUPDATE, this.onContainerUpdateWhilePlaying)
     this._stop('pause')
     this._start('watch')
   }
@@ -104,6 +105,7 @@ export default class ClapprStats extends ContainerPlugin {
     this._start('pause')
     this._inc('pause')
     this.listenToOnce(this.container, Events.CONTAINER_PLAY, this.playAfterPause)
+    this.stopListening(this.container, Events.CONTAINER_TIMEUPDATE, this.onContainerUpdateWhilePlaying)
   }
 
   onSeek(e) {

--- a/test/clappr-stats.spec.js
+++ b/test/clappr-stats.spec.js
@@ -92,6 +92,29 @@ describe('Clappr Stats', () => {
         assert.isOk(this.callback.calledOnce)
     })
 
+    it('does not update time watch in this events sequence [BUG]', () => {
+        let counter = 0
+        let originalMethod = window.performance.now
+        window.performance.now = () => { return counter++ }
+
+        let container = this.simulator.container
+        this.simulator.plugin.on(ClapprStats.REPORT_EVENT, this.callback)
+
+        container.play()
+        container.playing()
+        container.timeUpdated({current: 50})
+
+        container.paused()
+        container.timeUpdated({current: 80})
+        container.pause()
+
+        this.clock.tick(this.timeInterval)
+        let watch = this.callback.getCall(0).args[0].timers.watch
+
+        expect(watch).to.be.equal(3)
+        window.performance.now = originalMethod
+    })
+
     it('should update counters', () => {
         this.plugin.on(ClapprStats.REPORT_EVENT, this.callback)
         


### PR DESCRIPTION
There are a race condition when Clappr is playing mp4 video.