### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Usage
 
-You can use it from JSDelivr `https://cdn.jsdelivr.net/clappr.stats/latest/clappr-stats.min.js` or as a npm package.
+You can use it from JSDelivr `https://cdn.jsdelivr.net/npm/clappr-stats@latest/dist/clappr-stats.min.js` or as a npm package.
 
 ```html
 <script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/clappr-stats.

Feel free to ping me if you have any questions regarding this change.