### PR TITLE
Fix clappr-stats dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "author": "leandro.ribeiro.moreira@gmail.com",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "clappr": "^0.2.66",
     "lodash.get": "^4.3.0"
+  },
+  "peerDependencies": {
+    "clappr": "^0.2.66"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",
@@ -27,6 +29,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.24.1",
     "chai": "^4.0.2",
+    "clappr": "^0.2.66",
     "karma": "^1.7.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,12 +493,6 @@ babel-plugin-transform-regenerator@^6.24.1:
   dependencies:
     regenerator-transform "0.9.11"
 
-babel-plugin-transform-runtime@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -852,8 +846,8 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
 
 clappr@^0.2.66:
-  version "0.2.66"
-  resolved "https://registry.yarnpkg.com/clappr/-/clappr-0.2.66.tgz#657baf9d34c105cd1b41dbe2c72643077bb98285"
+  version "0.2.77"
+  resolved "https://registry.yarnpkg.com/clappr/-/clappr-0.2.77.tgz#f2e2941843375aa438b26e19f660ac550e8abca7"
 
 cliui@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
So today `clappr-stats` use `clappr` as dependecy, if you create any project and add these dependencies the node_modules folder will contain two `clappr`, one in root and other in `clappr-stats`. 

node_modules > clappr
node_modules > clappr-stats > node_modules > clappr

This issue only occur when `clappr` version is different that `clappr` specified in `clappr-stats` (package.json)