### PR TITLE
browser object for webpack in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "build": "node_modules/.bin/webpack",
     "release": "node_modules/.bin/webpack -p"
   },
+  "browser": {
+    "Clappr" : "clappr"
+  },
   "author": "leandro.ribeiro.moreira@gmail.com",
   "license": "BSD-3-Clause",
   "dependencies": {


### PR DESCRIPTION
Hello, I was trying to use `clappr-stats` with `webpack` and npm and I kept getting `Clappr cannot be resolved` Error. this minor change fixed the issue for me.

Thanks for the cool plugin and of course the awesome player 👍 😄 
