### PR TITLE
Fix: buffer percentage calculation

### DIFF
--- a/src/clappr-stats.js
+++ b/src/clappr-stats.js
@@ -234,10 +234,15 @@ export default class ClapprStats extends ContainerPlugin {
   }
 
   _calculatePercentages() {
-     if (this._metrics.extra.duration > 0) {
-       this._metrics.extra.bufferingPercentage = (this._metrics.timers.buffering / this._metrics.extra.duration) * 100
-     }
-  }
+    if(isNaN(this._metrics.extra.buffersize)){
+       this._metrics.extra.bufferingPercentage = NaN
+       return;
+    }
+
+    if (this._metrics.extra.duration > 0) {
+      this._metrics.extra.bufferingPercentage = (this._metrics.extra.buffersize / this._metrics.extra.duration) * 100
+    }
+ }
 
   _html5FetchFPS() {
     const videoTag = this.container.playback.el

--- a/test/clappr-stats.spec.js
+++ b/test/clappr-stats.spec.js
@@ -1,5 +1,5 @@
 import { expect, assert } from 'chai'
-
+import { Container, Playback } from 'clappr'
 import ClapprStats from '../src/clappr-stats'
 import { PlayerSimulator } from './util'
 
@@ -148,5 +148,42 @@ describe('Clappr Stats', () => {
         expect(metrics.timers.startup).to.be.an('number')
         expect(metrics.timers.watch).to.be.an('number')
         expect(metrics.timers.session).to.be.an('number')
+    })
+
+    describe(' _calculatePercentages', () => {
+      let pluginStats
+  
+      before(function() {
+        const container = new Container({ playback: new Playback() })
+        pluginStats = new ClapprStats(container)
+        container.addPlugin(pluginStats)
+      })
+  
+      it(' when buffersize prop is not available retuns NaN', () => {
+        //given
+        pluginStats._metrics.extra.duration = 234
+        pluginStats._metrics.extra.buffersize = NaN
+  
+        //when
+        pluginStats._calculatePercentages()
+  
+        //then
+        expect(pluginStats._metrics.extra.bufferingPercentage).to.be.NaN
+      })
+  
+      it(' when buffersize prop is available retuns value', () => {
+        //given
+        pluginStats._metrics.extra.duration = 234
+        pluginStats._metrics.extra.buffersize = 117
+        const expectReturn = 50
+  
+        //when
+        pluginStats._calculatePercentages()
+  
+        //then
+        expect(pluginStats._metrics.extra.bufferingPercentage).to.be.equal(
+          expectReturn
+        )
+      })
     })
 })


### PR DESCRIPTION
## Summary
Calculating percentage of buffer loaded was not using buffersize prop.

## Changes
Changed method code: _calculatePercentage to use the prop: buffersize available on object: extra.

## How to test
Added unit tests for return verification

## Suggestions: 
Mayor change, because function return may be NaN.